### PR TITLE
Move the dependencies from the Gemfile to the gemspec.  Differentiate…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,3 @@
 source "http://rubygems.org"
+
 gemspec
-
-gem "rake", "~> 10.1.1"
-gem "colored"
-gem "parallel"
-
-group :test do
-  gem "rspec", "~> 2.12"
-  gem "ci_reporter", "~> 1.9.0"
-end
-

--- a/lib/openstudio/recommendation_engine/version.rb
+++ b/lib/openstudio/recommendation_engine/version.rb
@@ -19,6 +19,6 @@
 
 module OpenStudio
   module RecommendationEngine
-    VERSION = "0.1.5"
+    VERSION = "0.1.6"
   end
 end

--- a/openstudio-recommendation-engine.gemspec
+++ b/openstudio-recommendation-engine.gemspec
@@ -14,8 +14,13 @@ Gem::Specification.new do |s|
   s.description = "This gem contains the framework needed to execute the recommendation engine on measures that have defined their recommendations."
   s.license = "LGPL"
 
-  s.add_runtime_dependency("parallel")
+  s.add_runtime_dependency("rake", "~> 10.1.1")
+  s.add_runtime_dependency("colored")
+  s.add_runtime_dependency("parallel", "~> 1.19.0")
   s.add_runtime_dependency("json_pure")
+
+  s.add_development_dependency("rspec", "~> 2.12")
+  s.add_development_dependency("ci_reporter", "~> 1.9.0")
 
   s.required_ruby_version = '>= 1.8.7'
   


### PR DESCRIPTION
… between runtime and development dependencies. Restrict gems so they don't require Ruby 2.5.
Satisfies issue #1.